### PR TITLE
Better views implementation

### DIFF
--- a/benches/blas-speedup/axpy.rs
+++ b/benches/blas-speedup/axpy.rs
@@ -5,7 +5,7 @@ use poc_kokkos_rs::{
         parallel_for,
         parameters::{ExecutionPolicy, ExecutionSpace, RangePolicy, Schedule},
     },
-    view::{parameters::Layout, ViewOwned},
+    view::{parameters::Layout, View},
 };
 use rand::{
     distributions::{Distribution, Uniform},
@@ -16,8 +16,8 @@ use rand::{
 // Serial AXPY
 fn f1(x_init: Vec<f64>, y_init: Vec<f64>, alpha: f64) {
     let length = x_init.len();
-    let mut x = ViewOwned::new_from_data(x_init, Layout::Right, [length]);
-    let mut y = ViewOwned::new_from_data(y_init, Layout::Right, [length]);
+    let mut x = View::new_from_data(x_init, Layout::Right, [length]);
+    let mut y = View::new_from_data(y_init, Layout::Right, [length]);
     black_box(&mut x);
     black_box(&mut y);
 
@@ -43,8 +43,8 @@ fn f1(x_init: Vec<f64>, y_init: Vec<f64>, alpha: f64) {
 // DeviceCPU AXPY
 fn f2(x_init: Vec<f64>, y_init: Vec<f64>, alpha: f64) {
     let length = x_init.len();
-    let mut x = ViewOwned::new_from_data(x_init, Layout::Right, [length]);
-    let mut y = ViewOwned::new_from_data(y_init, Layout::Right, [length]);
+    let mut x = View::new_from_data(x_init, Layout::Right, [length]);
+    let mut y = View::new_from_data(y_init, Layout::Right, [length]);
     black_box(&mut x);
     black_box(&mut y);
 

--- a/benches/blas-speedup/axpy.rs
+++ b/benches/blas-speedup/axpy.rs
@@ -5,7 +5,7 @@ use poc_kokkos_rs::{
         parallel_for,
         parameters::{ExecutionPolicy, ExecutionSpace, RangePolicy, Schedule},
     },
-    view::{parameters::Layout, View},
+    view::{parameters::MemoryLayout, View},
 };
 use rand::{
     distributions::{Distribution, Uniform},
@@ -16,8 +16,8 @@ use rand::{
 // Serial AXPY
 fn f1(x_init: Vec<f64>, y_init: Vec<f64>, alpha: f64) {
     let length = x_init.len();
-    let mut x = View::new_from_data(x_init, Layout::Right, [length]);
-    let mut y = View::new_from_data(y_init, Layout::Right, [length]);
+    let mut x = View::new_from_data(x_init, MemoryLayout::Right, [length]);
+    let mut y = View::new_from_data(y_init, MemoryLayout::Right, [length]);
     black_box(&mut x);
     black_box(&mut y);
 
@@ -43,8 +43,8 @@ fn f1(x_init: Vec<f64>, y_init: Vec<f64>, alpha: f64) {
 // DeviceCPU AXPY
 fn f2(x_init: Vec<f64>, y_init: Vec<f64>, alpha: f64) {
     let length = x_init.len();
-    let mut x = View::new_from_data(x_init, Layout::Right, [length]);
-    let mut y = View::new_from_data(y_init, Layout::Right, [length]);
+    let mut x = View::new_from_data(x_init, MemoryLayout::Right, [length]);
+    let mut y = View::new_from_data(y_init, MemoryLayout::Right, [length]);
     black_box(&mut x);
     black_box(&mut y);
 

--- a/benches/blas-speedup/gemm.rs
+++ b/benches/blas-speedup/gemm.rs
@@ -5,7 +5,7 @@ use poc_kokkos_rs::{
         parallel_for,
         parameters::{ExecutionPolicy, ExecutionSpace, RangePolicy, Schedule},
     },
-    view::{parameters::Layout, ViewOwned},
+    view::{parameters::Layout, View},
 };
 use rand::{
     distributions::{Distribution, Uniform},
@@ -22,9 +22,9 @@ fn f1(
     alpha: f64,
     beta: f64,
 ) {
-    let mut aa = ViewOwned::new_from_data(aa_init, Layout::Right, [length, length]);
-    let mut bb = ViewOwned::new_from_data(bb_init, Layout::Left, [length, length]); // optimal layout since we iterate inside columns :)
-    let mut cc = ViewOwned::new_from_data(cc_init, Layout::Right, [length, length]);
+    let mut aa = View::new_from_data(aa_init, Layout::Right, [length, length]);
+    let mut bb = View::new_from_data(bb_init, Layout::Left, [length, length]); // optimal layout since we iterate inside columns :)
+    let mut cc = View::new_from_data(cc_init, Layout::Right, [length, length]);
     black_box(&mut aa);
     black_box(&mut bb);
     black_box(&mut cc);
@@ -63,9 +63,9 @@ fn f2(
     alpha: f64,
     beta: f64,
 ) {
-    let mut aa = ViewOwned::new_from_data(aa_init, Layout::Right, [length, length]);
-    let mut bb = ViewOwned::new_from_data(bb_init, Layout::Left, [length, length]); // optimal layout since we iterate inside columns :)
-    let mut cc = ViewOwned::new_from_data(cc_init, Layout::Right, [length, length]);
+    let mut aa = View::new_from_data(aa_init, Layout::Right, [length, length]);
+    let mut bb = View::new_from_data(bb_init, Layout::Left, [length, length]); // optimal layout since we iterate inside columns :)
+    let mut cc = View::new_from_data(cc_init, Layout::Right, [length, length]);
     black_box(&mut aa);
     black_box(&mut bb);
     black_box(&mut cc);

--- a/benches/blas-speedup/gemm.rs
+++ b/benches/blas-speedup/gemm.rs
@@ -5,7 +5,7 @@ use poc_kokkos_rs::{
         parallel_for,
         parameters::{ExecutionPolicy, ExecutionSpace, RangePolicy, Schedule},
     },
-    view::{parameters::Layout, View},
+    view::{parameters::MemoryLayout, View},
 };
 use rand::{
     distributions::{Distribution, Uniform},
@@ -22,9 +22,9 @@ fn f1(
     alpha: f64,
     beta: f64,
 ) {
-    let mut aa = View::new_from_data(aa_init, Layout::Right, [length, length]);
-    let mut bb = View::new_from_data(bb_init, Layout::Left, [length, length]); // optimal layout since we iterate inside columns :)
-    let mut cc = View::new_from_data(cc_init, Layout::Right, [length, length]);
+    let mut aa = View::new_from_data(aa_init, MemoryLayout::Right, [length, length]);
+    let mut bb = View::new_from_data(bb_init, MemoryLayout::Left, [length, length]); // optimal layout since we iterate inside columns :)
+    let mut cc = View::new_from_data(cc_init, MemoryLayout::Right, [length, length]);
     black_box(&mut aa);
     black_box(&mut bb);
     black_box(&mut cc);
@@ -63,9 +63,9 @@ fn f2(
     alpha: f64,
     beta: f64,
 ) {
-    let mut aa = View::new_from_data(aa_init, Layout::Right, [length, length]);
-    let mut bb = View::new_from_data(bb_init, Layout::Left, [length, length]); // optimal layout since we iterate inside columns :)
-    let mut cc = View::new_from_data(cc_init, Layout::Right, [length, length]);
+    let mut aa = View::new_from_data(aa_init, MemoryLayout::Right, [length, length]);
+    let mut bb = View::new_from_data(bb_init, MemoryLayout::Left, [length, length]); // optimal layout since we iterate inside columns :)
+    let mut cc = View::new_from_data(cc_init, MemoryLayout::Right, [length, length]);
     black_box(&mut aa);
     black_box(&mut bb);
     black_box(&mut cc);

--- a/benches/blas-speedup/gemv.rs
+++ b/benches/blas-speedup/gemv.rs
@@ -5,7 +5,7 @@ use poc_kokkos_rs::{
         parallel_for,
         parameters::{ExecutionPolicy, ExecutionSpace, RangePolicy, Schedule},
     },
-    view::{parameters::Layout, View},
+    view::{parameters::MemoryLayout, View},
 };
 use rand::{
     distributions::{Distribution, Uniform},
@@ -16,9 +16,9 @@ use rand::{
 // Serial GEMV
 fn f1(aa_init: Vec<f64>, x_init: Vec<f64>, y_init: Vec<f64>, alpha: f64, beta: f64) {
     let length = x_init.len();
-    let mut aa = View::new_from_data(aa_init, Layout::Right, [length, length]);
-    let mut x = View::new_from_data(x_init, Layout::Right, [length]);
-    let mut y = View::new_from_data(y_init, Layout::Right, [length]);
+    let mut aa = View::new_from_data(aa_init, MemoryLayout::Right, [length, length]);
+    let mut x = View::new_from_data(x_init, MemoryLayout::Right, [length]);
+    let mut y = View::new_from_data(y_init, MemoryLayout::Right, [length]);
     black_box(&mut aa);
     black_box(&mut x);
     black_box(&mut y);
@@ -46,9 +46,9 @@ fn f1(aa_init: Vec<f64>, x_init: Vec<f64>, y_init: Vec<f64>, alpha: f64, beta: f
 // DeviceCPU GEMV
 fn f2(aa_init: Vec<f64>, x_init: Vec<f64>, y_init: Vec<f64>, alpha: f64, beta: f64) {
     let length = x_init.len();
-    let mut aa = View::new_from_data(aa_init, Layout::Right, [length, length]);
-    let mut x = View::new_from_data(x_init, Layout::Right, [length]);
-    let mut y = View::new_from_data(y_init, Layout::Right, [length]);
+    let mut aa = View::new_from_data(aa_init, MemoryLayout::Right, [length, length]);
+    let mut x = View::new_from_data(x_init, MemoryLayout::Right, [length]);
+    let mut y = View::new_from_data(y_init, MemoryLayout::Right, [length]);
     black_box(&mut aa);
     black_box(&mut x);
     black_box(&mut y);

--- a/benches/blas-speedup/gemv.rs
+++ b/benches/blas-speedup/gemv.rs
@@ -5,7 +5,7 @@ use poc_kokkos_rs::{
         parallel_for,
         parameters::{ExecutionPolicy, ExecutionSpace, RangePolicy, Schedule},
     },
-    view::{parameters::Layout, ViewOwned},
+    view::{parameters::Layout, View},
 };
 use rand::{
     distributions::{Distribution, Uniform},
@@ -16,9 +16,9 @@ use rand::{
 // Serial GEMV
 fn f1(aa_init: Vec<f64>, x_init: Vec<f64>, y_init: Vec<f64>, alpha: f64, beta: f64) {
     let length = x_init.len();
-    let mut aa = ViewOwned::new_from_data(aa_init, Layout::Right, [length, length]);
-    let mut x = ViewOwned::new_from_data(x_init, Layout::Right, [length]);
-    let mut y = ViewOwned::new_from_data(y_init, Layout::Right, [length]);
+    let mut aa = View::new_from_data(aa_init, Layout::Right, [length, length]);
+    let mut x = View::new_from_data(x_init, Layout::Right, [length]);
+    let mut y = View::new_from_data(y_init, Layout::Right, [length]);
     black_box(&mut aa);
     black_box(&mut x);
     black_box(&mut y);
@@ -46,9 +46,9 @@ fn f1(aa_init: Vec<f64>, x_init: Vec<f64>, y_init: Vec<f64>, alpha: f64, beta: f
 // DeviceCPU GEMV
 fn f2(aa_init: Vec<f64>, x_init: Vec<f64>, y_init: Vec<f64>, alpha: f64, beta: f64) {
     let length = x_init.len();
-    let mut aa = ViewOwned::new_from_data(aa_init, Layout::Right, [length, length]);
-    let mut x = ViewOwned::new_from_data(x_init, Layout::Right, [length]);
-    let mut y = ViewOwned::new_from_data(y_init, Layout::Right, [length]);
+    let mut aa = View::new_from_data(aa_init, Layout::Right, [length, length]);
+    let mut x = View::new_from_data(x_init, Layout::Right, [length]);
+    let mut y = View::new_from_data(y_init, Layout::Right, [length]);
     black_box(&mut aa);
     black_box(&mut x);
     black_box(&mut y);

--- a/benches/layout/comparison.rs
+++ b/benches/layout/comparison.rs
@@ -5,7 +5,7 @@ use poc_kokkos_rs::{
         parallel_for,
         parameters::{ExecutionPolicy, ExecutionSpace, RangePolicy, Schedule},
     },
-    view::{parameters::Layout, ViewOwned},
+    view::{parameters::Layout, View},
 };
 use rand::{
     distributions::{Distribution, Uniform},
@@ -25,9 +25,9 @@ fn f1(
     // worst case layout:
     // iterate on lines -> column-major layout (Left)
     // iterate on rows  -> line-major layout   (Right)
-    let mut aa = ViewOwned::new_from_data(aa_init, Layout::Left, [length, length]);
-    let mut bb = ViewOwned::new_from_data(bb_init, Layout::Right, [length, length]);
-    let mut cc = ViewOwned::new_from_data(cc_init, Layout::Left, [length, length]);
+    let mut aa = View::new_from_data(aa_init, Layout::Left, [length, length]);
+    let mut bb = View::new_from_data(bb_init, Layout::Right, [length, length]);
+    let mut cc = View::new_from_data(cc_init, Layout::Left, [length, length]);
     black_box(&mut aa);
     black_box(&mut bb);
     black_box(&mut cc);
@@ -69,9 +69,9 @@ fn f2(
     // best case layout:
     // iterate on lines -> line-major layout   (Right)
     // iterate on rows  -> column-major layout (Left)
-    let mut aa = ViewOwned::new_from_data(aa_init, Layout::Right, [length, length]);
-    let mut bb = ViewOwned::new_from_data(bb_init, Layout::Right, [length, length]);
-    let mut cc = ViewOwned::new_from_data(cc_init, Layout::Right, [length, length]);
+    let mut aa = View::new_from_data(aa_init, Layout::Right, [length, length]);
+    let mut bb = View::new_from_data(bb_init, Layout::Right, [length, length]);
+    let mut cc = View::new_from_data(cc_init, Layout::Right, [length, length]);
     black_box(&mut aa);
     black_box(&mut bb);
     black_box(&mut cc);
@@ -110,9 +110,9 @@ fn f3(
     alpha: f64,
     beta: f64,
 ) {
-    let mut aa = ViewOwned::new_from_data(aa_init, Layout::Right, [length, length]);
-    let mut bb = ViewOwned::new_from_data(bb_init, Layout::Left, [length, length]);
-    let mut cc = ViewOwned::new_from_data(cc_init, Layout::Right, [length, length]);
+    let mut aa = View::new_from_data(aa_init, Layout::Right, [length, length]);
+    let mut bb = View::new_from_data(bb_init, Layout::Left, [length, length]);
+    let mut cc = View::new_from_data(cc_init, Layout::Right, [length, length]);
     black_box(&mut aa);
     black_box(&mut bb);
     black_box(&mut cc);

--- a/benches/layout/comparison.rs
+++ b/benches/layout/comparison.rs
@@ -5,7 +5,7 @@ use poc_kokkos_rs::{
         parallel_for,
         parameters::{ExecutionPolicy, ExecutionSpace, RangePolicy, Schedule},
     },
-    view::{parameters::Layout, View},
+    view::{parameters::MemoryLayout, View},
 };
 use rand::{
     distributions::{Distribution, Uniform},
@@ -25,9 +25,9 @@ fn f1(
     // worst case layout:
     // iterate on lines -> column-major layout (Left)
     // iterate on rows  -> line-major layout   (Right)
-    let mut aa = View::new_from_data(aa_init, Layout::Left, [length, length]);
-    let mut bb = View::new_from_data(bb_init, Layout::Right, [length, length]);
-    let mut cc = View::new_from_data(cc_init, Layout::Left, [length, length]);
+    let mut aa = View::new_from_data(aa_init, MemoryLayout::Left, [length, length]);
+    let mut bb = View::new_from_data(bb_init, MemoryLayout::Right, [length, length]);
+    let mut cc = View::new_from_data(cc_init, MemoryLayout::Left, [length, length]);
     black_box(&mut aa);
     black_box(&mut bb);
     black_box(&mut cc);
@@ -69,9 +69,9 @@ fn f2(
     // best case layout:
     // iterate on lines -> line-major layout   (Right)
     // iterate on rows  -> column-major layout (Left)
-    let mut aa = View::new_from_data(aa_init, Layout::Right, [length, length]);
-    let mut bb = View::new_from_data(bb_init, Layout::Right, [length, length]);
-    let mut cc = View::new_from_data(cc_init, Layout::Right, [length, length]);
+    let mut aa = View::new_from_data(aa_init, MemoryLayout::Right, [length, length]);
+    let mut bb = View::new_from_data(bb_init, MemoryLayout::Right, [length, length]);
+    let mut cc = View::new_from_data(cc_init, MemoryLayout::Right, [length, length]);
     black_box(&mut aa);
     black_box(&mut bb);
     black_box(&mut cc);
@@ -110,9 +110,9 @@ fn f3(
     alpha: f64,
     beta: f64,
 ) {
-    let mut aa = View::new_from_data(aa_init, Layout::Right, [length, length]);
-    let mut bb = View::new_from_data(bb_init, Layout::Left, [length, length]);
-    let mut cc = View::new_from_data(cc_init, Layout::Right, [length, length]);
+    let mut aa = View::new_from_data(aa_init, MemoryLayout::Right, [length, length]);
+    let mut bb = View::new_from_data(bb_init, MemoryLayout::Left, [length, length]);
+    let mut cc = View::new_from_data(cc_init, MemoryLayout::Right, [length, length]);
     black_box(&mut aa);
     black_box(&mut bb);
     black_box(&mut cc);

--- a/benches/layout/size.rs
+++ b/benches/layout/size.rs
@@ -5,7 +5,7 @@ use poc_kokkos_rs::{
         parallel_for,
         parameters::{ExecutionPolicy, ExecutionSpace, RangePolicy, Schedule},
     },
-    view::{parameters::Layout, ViewOwned},
+    view::{parameters::Layout, View},
 };
 use rand::{
     distributions::{Distribution, Uniform},
@@ -27,9 +27,9 @@ fn f1(
     // best case layout:
     // iterate on lines -> line-major layout   (Right)
     // iterate on rows  -> column-major layout (Left)
-    let mut aa = ViewOwned::new_from_data(aa_init, Layout::Right, [length, length]);
-    let mut bb = ViewOwned::new_from_data(bb_init, Layout::Right, [length, length]);
-    let mut cc = ViewOwned::new_from_data(cc_init, Layout::Right, [length, length]);
+    let mut aa = View::new_from_data(aa_init, Layout::Right, [length, length]);
+    let mut bb = View::new_from_data(bb_init, Layout::Right, [length, length]);
+    let mut cc = View::new_from_data(cc_init, Layout::Right, [length, length]);
     black_box(&mut aa);
     black_box(&mut bb);
     black_box(&mut cc);
@@ -68,9 +68,9 @@ fn f2(
     alpha: FloatType,
     beta: FloatType,
 ) {
-    let mut aa = ViewOwned::new_from_data(aa_init, Layout::Right, [length, length]);
-    let mut bb = ViewOwned::new_from_data(bb_init, Layout::Left, [length, length]);
-    let mut cc = ViewOwned::new_from_data(cc_init, Layout::Right, [length, length]);
+    let mut aa = View::new_from_data(aa_init, Layout::Right, [length, length]);
+    let mut bb = View::new_from_data(bb_init, Layout::Left, [length, length]);
+    let mut cc = View::new_from_data(cc_init, Layout::Right, [length, length]);
     black_box(&mut aa);
     black_box(&mut bb);
     black_box(&mut cc);

--- a/benches/layout/size.rs
+++ b/benches/layout/size.rs
@@ -5,7 +5,7 @@ use poc_kokkos_rs::{
         parallel_for,
         parameters::{ExecutionPolicy, ExecutionSpace, RangePolicy, Schedule},
     },
-    view::{parameters::Layout, View},
+    view::{parameters::MemoryLayout, View},
 };
 use rand::{
     distributions::{Distribution, Uniform},
@@ -27,9 +27,9 @@ fn f1(
     // best case layout:
     // iterate on lines -> line-major layout   (Right)
     // iterate on rows  -> column-major layout (Left)
-    let mut aa = View::new_from_data(aa_init, Layout::Right, [length, length]);
-    let mut bb = View::new_from_data(bb_init, Layout::Right, [length, length]);
-    let mut cc = View::new_from_data(cc_init, Layout::Right, [length, length]);
+    let mut aa = View::new_from_data(aa_init, MemoryLayout::Right, [length, length]);
+    let mut bb = View::new_from_data(bb_init, MemoryLayout::Right, [length, length]);
+    let mut cc = View::new_from_data(cc_init, MemoryLayout::Right, [length, length]);
     black_box(&mut aa);
     black_box(&mut bb);
     black_box(&mut cc);
@@ -68,9 +68,9 @@ fn f2(
     alpha: FloatType,
     beta: FloatType,
 ) {
-    let mut aa = View::new_from_data(aa_init, Layout::Right, [length, length]);
-    let mut bb = View::new_from_data(bb_init, Layout::Left, [length, length]);
-    let mut cc = View::new_from_data(cc_init, Layout::Right, [length, length]);
+    let mut aa = View::new_from_data(aa_init, MemoryLayout::Right, [length, length]);
+    let mut bb = View::new_from_data(bb_init, MemoryLayout::Left, [length, length]);
+    let mut cc = View::new_from_data(cc_init, MemoryLayout::Right, [length, length]);
     black_box(&mut aa);
     black_box(&mut bb);
     black_box(&mut cc);

--- a/benches/view_access.rs
+++ b/benches/view_access.rs
@@ -18,7 +18,7 @@ fn f1(length: usize, indices: &[usize]) {
 
 // 1D view access
 fn f1_b(length: usize, indices: &[usize]) {
-    let v_y: View<'_, 1, f64> = View::new_from_data(vec![0.0; length], Layout::Right, [length]);
+    let v_y: View<1, f64> = View::new_from_data(vec![0.0; length], Layout::Right, [length]);
     let idx = &indices[0..length];
 
     idx.iter().for_each(|i| {
@@ -40,7 +40,7 @@ fn f2(length: usize, indices: &[(usize, usize)]) {
 
 // 2D view access
 fn f2_b(length: usize, indices: &[(usize, usize)]) {
-    let v_y: View<'_, 2, f64> =
+    let v_y: View<2, f64> =
         View::new_from_data(vec![0.0; length * length], Layout::Right, [length, length]);
     let idx = &indices[0..length];
 
@@ -70,7 +70,7 @@ fn f3(length: usize, indices: &[(usize, usize, usize)]) {
 
 // 3D view access
 fn f3_b(length: usize, indices: &[(usize, usize, usize)]) {
-    let v_y: View<'_, 3, f64> = View::new_from_data(
+    let v_y: View<3, f64> = View::new_from_data(
         vec![0.0; length * length * length],
         Layout::Right,
         [length, length, length],

--- a/benches/view_access.rs
+++ b/benches/view_access.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use poc_kokkos_rs::view::{parameters::Layout, View};
+use poc_kokkos_rs::view::{parameters::MemoryLayout, View};
 use rand::prelude::*;
 
 // this bench is used to evaluate the cost of accessing views' data
@@ -18,7 +18,7 @@ fn f1(length: usize, indices: &[usize]) {
 
 // 1D view access
 fn f1_b(length: usize, indices: &[usize]) {
-    let v_y: View<1, f64> = View::new_from_data(vec![0.0; length], Layout::Right, [length]);
+    let v_y: View<1, f64> = View::new_from_data(vec![0.0; length], MemoryLayout::Right, [length]);
     let idx = &indices[0..length];
 
     idx.iter().for_each(|i| {
@@ -40,8 +40,11 @@ fn f2(length: usize, indices: &[(usize, usize)]) {
 
 // 2D view access
 fn f2_b(length: usize, indices: &[(usize, usize)]) {
-    let v_y: View<2, f64> =
-        View::new_from_data(vec![0.0; length * length], Layout::Right, [length, length]);
+    let v_y: View<2, f64> = View::new_from_data(
+        vec![0.0; length * length],
+        MemoryLayout::Right,
+        [length, length],
+    );
     let idx = &indices[0..length];
 
     idx.iter().for_each(|(i, j)| {
@@ -72,7 +75,7 @@ fn f3(length: usize, indices: &[(usize, usize, usize)]) {
 fn f3_b(length: usize, indices: &[(usize, usize, usize)]) {
     let v_y: View<3, f64> = View::new_from_data(
         vec![0.0; length * length * length],
-        Layout::Right,
+        MemoryLayout::Right,
         [length, length, length],
     );
     let idx = &indices[0..length];

--- a/benches/view_access.rs
+++ b/benches/view_access.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use poc_kokkos_rs::view::{parameters::Layout, ViewOwned};
+use poc_kokkos_rs::view::{parameters::Layout, View};
 use rand::prelude::*;
 
 // this bench is used to evaluate the cost of accessing views' data
@@ -18,8 +18,7 @@ fn f1(length: usize, indices: &[usize]) {
 
 // 1D view access
 fn f1_b(length: usize, indices: &[usize]) {
-    let v_y: ViewOwned<'_, 1, f64> =
-        ViewOwned::new_from_data(vec![0.0; length], Layout::Right, [length]);
+    let v_y: View<'_, 1, f64> = View::new_from_data(vec![0.0; length], Layout::Right, [length]);
     let idx = &indices[0..length];
 
     idx.iter().for_each(|i| {
@@ -41,8 +40,8 @@ fn f2(length: usize, indices: &[(usize, usize)]) {
 
 // 2D view access
 fn f2_b(length: usize, indices: &[(usize, usize)]) {
-    let v_y: ViewOwned<'_, 2, f64> =
-        ViewOwned::new_from_data(vec![0.0; length * length], Layout::Right, [length, length]);
+    let v_y: View<'_, 2, f64> =
+        View::new_from_data(vec![0.0; length * length], Layout::Right, [length, length]);
     let idx = &indices[0..length];
 
     idx.iter().for_each(|(i, j)| {
@@ -71,7 +70,7 @@ fn f3(length: usize, indices: &[(usize, usize, usize)]) {
 
 // 3D view access
 fn f3_b(length: usize, indices: &[(usize, usize, usize)]) {
-    let v_y: ViewOwned<'_, 3, f64> = ViewOwned::new_from_data(
+    let v_y: View<'_, 3, f64> = View::new_from_data(
         vec![0.0; length * length * length],
         Layout::Right,
         [length, length, length],

--- a/benches/view_init.rs
+++ b/benches/view_init.rs
@@ -19,7 +19,7 @@ fn f1_b(size: u32) {
     let length = 2_usize.pow(size);
     for _ in 0..1000 {
         let y: Vec<f64> = vec![0.0; length];
-        let v_y: View<'_, 1, f64> = View::new_from_data(y, Layout::Right, [length]);
+        let v_y: View<1, f64> = View::new_from_data(y, Layout::Right, [length]);
         black_box(v_y);
     }
 }
@@ -28,7 +28,7 @@ fn f1_b(size: u32) {
 fn f1_bb(size: u32) {
     let length = 2_usize.pow(size);
     for _ in 0..1000 {
-        let v_y: View<'_, 1, f64> = View::new_from_data(vec![0.0; length], Layout::Right, [length]);
+        let v_y: View<1, f64> = View::new_from_data(vec![0.0; length], Layout::Right, [length]);
         black_box(v_y);
     }
 }
@@ -37,7 +37,7 @@ fn f1_bb(size: u32) {
 fn f1_bbb(size: u32) {
     let length = 2_usize.pow(size);
     for _ in 0..1000 {
-        let v_y: View<'_, 1, f64> = View::new(Layout::Right, [length]);
+        let v_y: View<1, f64> = View::new(Layout::Right, [length]);
         black_box(v_y);
     }
 }
@@ -58,7 +58,7 @@ fn f2_b(size: u32) {
     let length = 2_usize.pow(size);
     for _ in 0..100 {
         let y: Vec<f64> = vec![0.0; length * length];
-        let v_y: View<'_, 2, f64> = View::new_from_data(y, Layout::Right, [length, length]);
+        let v_y: View<2, f64> = View::new_from_data(y, Layout::Right, [length, length]);
         black_box(v_y);
     }
 }
@@ -67,7 +67,7 @@ fn f2_b(size: u32) {
 fn f2_bb(size: u32) {
     let length = 2_usize.pow(size);
     for _ in 0..100 {
-        let v_y: View<'_, 2, f64> =
+        let v_y: View<2, f64> =
             View::new_from_data(vec![0.0; length * length], Layout::Right, [length, length]);
         black_box(v_y);
     }
@@ -77,7 +77,7 @@ fn f2_bb(size: u32) {
 fn f2_bbb(size: u32) {
     let length = 2_usize.pow(size);
     for _ in 0..100 {
-        let v_y: View<'_, 2, f64> = View::new(Layout::Right, [length, length]);
+        let v_y: View<2, f64> = View::new(Layout::Right, [length, length]);
         black_box(v_y);
     }
 }

--- a/benches/view_init.rs
+++ b/benches/view_init.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use poc_kokkos_rs::view::{parameters::Layout, View};
+use poc_kokkos_rs::view::{parameters::MemoryLayout, View};
 
 // this bench is used to evaluate the cost of creating views
 
@@ -19,7 +19,7 @@ fn f1_b(size: u32) {
     let length = 2_usize.pow(size);
     for _ in 0..1000 {
         let y: Vec<f64> = vec![0.0; length];
-        let v_y: View<1, f64> = View::new_from_data(y, Layout::Right, [length]);
+        let v_y: View<1, f64> = View::new_from_data(y, MemoryLayout::Right, [length]);
         black_box(v_y);
     }
 }
@@ -28,7 +28,8 @@ fn f1_b(size: u32) {
 fn f1_bb(size: u32) {
     let length = 2_usize.pow(size);
     for _ in 0..1000 {
-        let v_y: View<1, f64> = View::new_from_data(vec![0.0; length], Layout::Right, [length]);
+        let v_y: View<1, f64> =
+            View::new_from_data(vec![0.0; length], MemoryLayout::Right, [length]);
         black_box(v_y);
     }
 }
@@ -37,7 +38,7 @@ fn f1_bb(size: u32) {
 fn f1_bbb(size: u32) {
     let length = 2_usize.pow(size);
     for _ in 0..1000 {
-        let v_y: View<1, f64> = View::new(Layout::Right, [length]);
+        let v_y: View<1, f64> = View::new(MemoryLayout::Right, [length]);
         black_box(v_y);
     }
 }
@@ -58,7 +59,7 @@ fn f2_b(size: u32) {
     let length = 2_usize.pow(size);
     for _ in 0..100 {
         let y: Vec<f64> = vec![0.0; length * length];
-        let v_y: View<2, f64> = View::new_from_data(y, Layout::Right, [length, length]);
+        let v_y: View<2, f64> = View::new_from_data(y, MemoryLayout::Right, [length, length]);
         black_box(v_y);
     }
 }
@@ -67,8 +68,11 @@ fn f2_b(size: u32) {
 fn f2_bb(size: u32) {
     let length = 2_usize.pow(size);
     for _ in 0..100 {
-        let v_y: View<2, f64> =
-            View::new_from_data(vec![0.0; length * length], Layout::Right, [length, length]);
+        let v_y: View<2, f64> = View::new_from_data(
+            vec![0.0; length * length],
+            MemoryLayout::Right,
+            [length, length],
+        );
         black_box(v_y);
     }
 }
@@ -77,7 +81,7 @@ fn f2_bb(size: u32) {
 fn f2_bbb(size: u32) {
     let length = 2_usize.pow(size);
     for _ in 0..100 {
-        let v_y: View<2, f64> = View::new(Layout::Right, [length, length]);
+        let v_y: View<2, f64> = View::new(MemoryLayout::Right, [length, length]);
         black_box(v_y);
     }
 }

--- a/benches/view_init.rs
+++ b/benches/view_init.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use poc_kokkos_rs::view::{parameters::Layout, ViewOwned};
+use poc_kokkos_rs::view::{parameters::Layout, View};
 
 // this bench is used to evaluate the cost of creating views
 
@@ -19,7 +19,7 @@ fn f1_b(size: u32) {
     let length = 2_usize.pow(size);
     for _ in 0..1000 {
         let y: Vec<f64> = vec![0.0; length];
-        let v_y: ViewOwned<'_, 1, f64> = ViewOwned::new_from_data(y, Layout::Right, [length]);
+        let v_y: View<'_, 1, f64> = View::new_from_data(y, Layout::Right, [length]);
         black_box(v_y);
     }
 }
@@ -28,8 +28,7 @@ fn f1_b(size: u32) {
 fn f1_bb(size: u32) {
     let length = 2_usize.pow(size);
     for _ in 0..1000 {
-        let v_y: ViewOwned<'_, 1, f64> =
-            ViewOwned::new_from_data(vec![0.0; length], Layout::Right, [length]);
+        let v_y: View<'_, 1, f64> = View::new_from_data(vec![0.0; length], Layout::Right, [length]);
         black_box(v_y);
     }
 }
@@ -38,7 +37,7 @@ fn f1_bb(size: u32) {
 fn f1_bbb(size: u32) {
     let length = 2_usize.pow(size);
     for _ in 0..1000 {
-        let v_y: ViewOwned<'_, 1, f64> = ViewOwned::new(Layout::Right, [length]);
+        let v_y: View<'_, 1, f64> = View::new(Layout::Right, [length]);
         black_box(v_y);
     }
 }
@@ -59,8 +58,7 @@ fn f2_b(size: u32) {
     let length = 2_usize.pow(size);
     for _ in 0..100 {
         let y: Vec<f64> = vec![0.0; length * length];
-        let v_y: ViewOwned<'_, 2, f64> =
-            ViewOwned::new_from_data(y, Layout::Right, [length, length]);
+        let v_y: View<'_, 2, f64> = View::new_from_data(y, Layout::Right, [length, length]);
         black_box(v_y);
     }
 }
@@ -69,8 +67,8 @@ fn f2_b(size: u32) {
 fn f2_bb(size: u32) {
     let length = 2_usize.pow(size);
     for _ in 0..100 {
-        let v_y: ViewOwned<'_, 2, f64> =
-            ViewOwned::new_from_data(vec![0.0; length * length], Layout::Right, [length, length]);
+        let v_y: View<'_, 2, f64> =
+            View::new_from_data(vec![0.0; length * length], Layout::Right, [length, length]);
         black_box(v_y);
     }
 }
@@ -79,7 +77,7 @@ fn f2_bb(size: u32) {
 fn f2_bbb(size: u32) {
     let length = 2_usize.pow(size);
     for _ in 0..100 {
-        let v_y: ViewOwned<'_, 2, f64> = ViewOwned::new(Layout::Right, [length, length]);
+        let v_y: View<'_, 2, f64> = View::new(Layout::Right, [length, length]);
         black_box(v_y);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use poc_kokkos_rs::{
         parallel_for,
         parameters::{ExecutionPolicy, ExecutionSpace, RangePolicy, Schedule},
     },
-    view::{parameters::Layout, View},
+    view::{parameters::MemoryLayout, View},
 };
 use rand::{distributions::Uniform, prelude::*, rngs::SmallRng, SeedableRng};
 
@@ -36,9 +36,9 @@ fn main() {
     let beta: f64 = range.sample(&mut rng);
 
     // inits again
-    let mut aa = View::new_from_data(aa_init, Layout::Right, [length, length]);
-    let mut bb = View::new_from_data(bb_init, Layout::Left, [length, length]); // optimal layout since we iterate inside columns :)
-    let mut cc = View::new_from_data(cc_init, Layout::Right, [length, length]);
+    let mut aa = View::new_from_data(aa_init, MemoryLayout::Right, [length, length]);
+    let mut bb = View::new_from_data(bb_init, MemoryLayout::Left, [length, length]); // optimal layout since we iterate inside columns :)
+    let mut cc = View::new_from_data(cc_init, MemoryLayout::Right, [length, length]);
     black_box(&mut aa);
     black_box(&mut bb);
     black_box(&mut cc);

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use poc_kokkos_rs::{
         parallel_for,
         parameters::{ExecutionPolicy, ExecutionSpace, RangePolicy, Schedule},
     },
-    view::{parameters::Layout, ViewOwned},
+    view::{parameters::Layout, View},
 };
 use rand::{distributions::Uniform, prelude::*, rngs::SmallRng, SeedableRng};
 
@@ -36,9 +36,9 @@ fn main() {
     let beta: f64 = range.sample(&mut rng);
 
     // inits again
-    let mut aa = ViewOwned::new_from_data(aa_init, Layout::Right, [length, length]);
-    let mut bb = ViewOwned::new_from_data(bb_init, Layout::Left, [length, length]); // optimal layout since we iterate inside columns :)
-    let mut cc = ViewOwned::new_from_data(cc_init, Layout::Right, [length, length]);
+    let mut aa = View::new_from_data(aa_init, Layout::Right, [length, length]);
+    let mut bb = View::new_from_data(bb_init, Layout::Left, [length, length]); // optimal layout since we iterate inside columns :)
+    let mut cc = View::new_from_data(cc_init, Layout::Right, [length, length]);
     black_box(&mut aa);
     black_box(&mut bb);
     black_box(&mut cc);

--- a/src/routines/dispatch.rs
+++ b/src/routines/dispatch.rs
@@ -384,7 +384,7 @@ mod tests {
 
         serial(execp, kernel).unwrap();
 
-        assert_eq!(mat.raw_val().unwrap(), ref_mat.raw_val().unwrap());
+        assert_eq!(mat.raw_val(), ref_mat.raw_val());
     }
 
     #[test]
@@ -419,7 +419,7 @@ mod tests {
 
         serial(execp, kernel).unwrap();
 
-        assert_eq!(mat.raw_val().unwrap(), ref_mat.raw_val().unwrap());
+        assert_eq!(mat.raw_val(), ref_mat.raw_val());
     }
 
     #[test]
@@ -455,6 +455,6 @@ mod tests {
         });
 
         serial(execp, kernel).unwrap();
-        assert_eq!(mat.raw_val().unwrap(), ref_mat.raw_val().unwrap());
+        assert_eq!(mat.raw_val(), ref_mat.raw_val());
     }
 }

--- a/src/routines/dispatch.rs
+++ b/src/routines/dispatch.rs
@@ -357,17 +357,17 @@ mod tests {
         use super::*;
         use crate::{
             routines::parameters::{ExecutionSpace, Schedule},
-            view::{parameters::Layout, ViewOwned},
+            view::{parameters::Layout, View},
         };
         // fixes warnings when testing using a parallel feature
         cfg_if::cfg_if! {
             if #[cfg(any(feature = "threads", feature = "rayon", feature = "gpu"))] {
-                let mat = ViewOwned::new_from_data(vec![0.0; 15], Layout::Right, [15]);
+                let mat = View::new_from_data(vec![0.0; 15], Layout::Right, [15]);
             } else {
-                let mut mat = ViewOwned::new_from_data(vec![0.0; 15], Layout::Right, [15]);
+                let mut mat = View::new_from_data(vec![0.0; 15], Layout::Right, [15]);
             }
         }
-        let ref_mat = ViewOwned::new_from_data(vec![1.0; 15], Layout::Right, [15]);
+        let ref_mat = View::new_from_data(vec![1.0; 15], Layout::Right, [15]);
         let rangep = RangePolicy::RangePolicy(0..15);
         let execp = ExecutionPolicy {
             space: ExecutionSpace::DeviceCPU,
@@ -392,17 +392,17 @@ mod tests {
         use super::*;
         use crate::{
             routines::parameters::{ExecutionSpace, Schedule},
-            view::{parameters::Layout, ViewOwned},
+            view::{parameters::Layout, View},
         };
         // fixes warnings when testing using a parallel feature
         cfg_if::cfg_if! {
             if #[cfg(any(feature = "threads", feature = "rayon", feature = "gpu"))] {
-                let mat = ViewOwned::new_from_data(vec![0.0; 150], Layout::Right, [10, 15]);
+                let mat = View::new_from_data(vec![0.0; 150], Layout::Right, [10, 15]);
             } else {
-                let mut mat = ViewOwned::new_from_data(vec![0.0; 150], Layout::Right, [10, 15]);
+                let mut mat = View::new_from_data(vec![0.0; 150], Layout::Right, [10, 15]);
             }
         }
-        let ref_mat = ViewOwned::new_from_data(vec![1.0; 150], Layout::Right, [10, 15]);
+        let ref_mat = View::new_from_data(vec![1.0; 150], Layout::Right, [10, 15]);
         let rangep = RangePolicy::MDRangePolicy([0..10, 0..15]);
         let execp = ExecutionPolicy {
             space: ExecutionSpace::DeviceCPU,
@@ -427,18 +427,18 @@ mod tests {
         use super::*;
         use crate::{
             routines::parameters::{ExecutionSpace, Schedule},
-            view::{parameters::Layout, ViewOwned},
+            view::{parameters::Layout, View},
         };
 
         // fixes warnings when testing using a parallel feature
         cfg_if::cfg_if! {
             if #[cfg(any(feature = "threads", feature = "rayon", feature = "gpu"))] {
-                let mat = ViewOwned::new_from_data(vec![0.0; 15], Layout::Right, [15]);
+                let mat = View::new_from_data(vec![0.0; 15], Layout::Right, [15]);
             } else {
-                let mut mat = ViewOwned::new_from_data(vec![0.0; 15], Layout::Right, [15]);
+                let mut mat = View::new_from_data(vec![0.0; 15], Layout::Right, [15]);
             }
         }
-        let ref_mat = ViewOwned::new_from_data(vec![1.0; 15], Layout::Right, [15]);
+        let ref_mat = View::new_from_data(vec![1.0; 15], Layout::Right, [15]);
         #[allow(clippy::single_range_in_vec_init)]
         let rangep = RangePolicy::MDRangePolicy([0..15]);
         let execp = ExecutionPolicy {

--- a/src/routines/dispatch.rs
+++ b/src/routines/dispatch.rs
@@ -357,17 +357,17 @@ mod tests {
         use super::*;
         use crate::{
             routines::parameters::{ExecutionSpace, Schedule},
-            view::{parameters::Layout, View},
+            view::{parameters::MemoryLayout, View},
         };
         // fixes warnings when testing using a parallel feature
         cfg_if::cfg_if! {
             if #[cfg(any(feature = "threads", feature = "rayon", feature = "gpu"))] {
-                let mat = View::new_from_data(vec![0.0; 15], Layout::Right, [15]);
+                let mat = View::new_from_data(vec![0.0; 15], MemoryLayout::Right, [15]);
             } else {
-                let mut mat = View::new_from_data(vec![0.0; 15], Layout::Right, [15]);
+                let mut mat = View::new_from_data(vec![0.0; 15], MemoryLayout::Right, [15]);
             }
         }
-        let ref_mat = View::new_from_data(vec![1.0; 15], Layout::Right, [15]);
+        let ref_mat = View::new_from_data(vec![1.0; 15], MemoryLayout::Right, [15]);
         let rangep = RangePolicy::RangePolicy(0..15);
         let execp = ExecutionPolicy {
             space: ExecutionSpace::DeviceCPU,
@@ -392,17 +392,17 @@ mod tests {
         use super::*;
         use crate::{
             routines::parameters::{ExecutionSpace, Schedule},
-            view::{parameters::Layout, View},
+            view::{parameters::MemoryLayout, View},
         };
         // fixes warnings when testing using a parallel feature
         cfg_if::cfg_if! {
             if #[cfg(any(feature = "threads", feature = "rayon", feature = "gpu"))] {
-                let mat = View::new_from_data(vec![0.0; 150], Layout::Right, [10, 15]);
+                let mat = View::new_from_data(vec![0.0; 150], MemoryLayout::Right, [10, 15]);
             } else {
-                let mut mat = View::new_from_data(vec![0.0; 150], Layout::Right, [10, 15]);
+                let mut mat = View::new_from_data(vec![0.0; 150], MemoryLayout::Right, [10, 15]);
             }
         }
-        let ref_mat = View::new_from_data(vec![1.0; 150], Layout::Right, [10, 15]);
+        let ref_mat = View::new_from_data(vec![1.0; 150], MemoryLayout::Right, [10, 15]);
         let rangep = RangePolicy::MDRangePolicy([0..10, 0..15]);
         let execp = ExecutionPolicy {
             space: ExecutionSpace::DeviceCPU,
@@ -427,18 +427,18 @@ mod tests {
         use super::*;
         use crate::{
             routines::parameters::{ExecutionSpace, Schedule},
-            view::{parameters::Layout, View},
+            view::{parameters::MemoryLayout, View},
         };
 
         // fixes warnings when testing using a parallel feature
         cfg_if::cfg_if! {
             if #[cfg(any(feature = "threads", feature = "rayon", feature = "gpu"))] {
-                let mat = View::new_from_data(vec![0.0; 15], Layout::Right, [15]);
+                let mat = View::new_from_data(vec![0.0; 15], MemoryLayout::Right, [15]);
             } else {
-                let mut mat = View::new_from_data(vec![0.0; 15], Layout::Right, [15]);
+                let mut mat = View::new_from_data(vec![0.0; 15], MemoryLayout::Right, [15]);
             }
         }
-        let ref_mat = View::new_from_data(vec![1.0; 15], Layout::Right, [15]);
+        let ref_mat = View::new_from_data(vec![1.0; 15], MemoryLayout::Right, [15]);
         #[allow(clippy::single_range_in_vec_init)]
         let rangep = RangePolicy::MDRangePolicy([0..15]);
         let execp = ExecutionPolicy {

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -53,6 +53,7 @@ use std::{fmt::Debug, ops::Index};
 ///
 /// In all variants, the internal value is a description of the error.
 pub enum ViewError<'a> {
+    Allocation(&'a str),
     ValueError(&'a str),
     DoubleMirroring(&'a str),
 }

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -91,11 +91,12 @@ where
         let capacity: usize = dim.iter().product();
 
         // build data holder
-        let data: ViewData<T> = ViewData::new(capacity, MemorySpace::CPU);
+        let mut viewdata: ViewData<T> = ViewData::new(capacity, MemorySpace::CPU);
+        viewdata.fill(T::default());
 
         // build & return
         Self {
-            data,
+            data: viewdata,
             layout,
             dim,
             stride,

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -16,12 +16,12 @@
 //! Initialize and fill a 2D matrix:
 //! ```rust
 //! use poc_kokkos_rs::view::{
-//!     parameters::Layout,
+//!     parameters::MemoryLayout,
 //!     View,
 //! };
 //!
 //! let mut viewA: View<2, f64> = View::new(
-//!         Layout::Right, // see parameters & Kokkos doc
+//!         MemoryLayout::Right, // see parameters & Kokkos doc
 //!         [3, 5],        // 3 rows, 5 columns
 //!     );
 //!
@@ -45,7 +45,7 @@ use atomic::{Atomic, Ordering};
 #[cfg(any(doc, not(any(feature = "rayon", feature = "threads", feature = "gpu"))))]
 use std::ops::IndexMut;
 
-use self::parameters::{compute_stride, DataTraits, InnerDataType, Layout};
+use self::parameters::{compute_stride, DataTraits, InnerDataType, MemoryLayout};
 use std::{fmt::Debug, ops::Index};
 
 #[derive(Debug)]
@@ -70,7 +70,7 @@ where
     /// (`ReadOnly`) or a mutable reference (`ReadWrite`).
     pub data: Vec<InnerDataType<T>>,
     /// Memory layout of the view. Refer to Kokkos documentation for more information.
-    pub layout: Layout<N>,
+    pub layout: MemoryLayout<N>,
     /// Dimensions of the data represented by the view. The view can:
     /// - be a vector (1 dimension)
     /// - be a multi-dimensionnal array (up to 8 dimensions)
@@ -78,7 +78,7 @@ where
     /// is not directly supported at the moment.
     pub dim: [usize; N],
     /// Stride between each element of a given dimension. Computed automatically for
-    /// [Layout::Left] and [Layout::Right].
+    /// [MemoryLayout::Left] and [MemoryLayout::Right].
     pub stride: [usize; N],
 }
 
@@ -89,7 +89,7 @@ where
     T: DataTraits, // fair assumption imo
 {
     /// Constructor used to create owned views. See dedicated methods for others.
-    pub fn new(layout: Layout<N>, dim: [usize; N]) -> Self {
+    pub fn new(layout: MemoryLayout<N>, dim: [usize; N]) -> Self {
         // compute stride & capacity
         let stride = compute_stride(&dim, &layout);
         let capacity: usize = dim.iter().product();
@@ -104,7 +104,7 @@ where
     }
 
     /// Constructor used to create owned views. See dedicated methods for others.
-    pub fn new_from_data(data: Vec<T>, layout: Layout<N>, dim: [usize; N]) -> Self {
+    pub fn new_from_data(data: Vec<T>, layout: MemoryLayout<N>, dim: [usize; N]) -> Self {
         // compute stride if necessary
         let stride = compute_stride(&dim, &layout);
 
@@ -129,7 +129,7 @@ where
     T: DataTraits, // fair assumption imo
 {
     /// Constructor used to create owned views. See dedicated methods for others.
-    pub fn new(layout: Layout<N>, dim: [usize; N]) -> Self {
+    pub fn new(layout: MemoryLayout<N>, dim: [usize; N]) -> Self {
         // compute stride & capacity
         let stride = compute_stride(&dim, &layout);
         let capacity: usize = dim.iter().product();
@@ -144,7 +144,7 @@ where
     }
 
     /// Constructor used to create owned views. See dedicated methods for others.
-    pub fn new_from_data(data: Vec<T>, layout: Layout<N>, dim: [usize; N]) -> Self {
+    pub fn new_from_data(data: Vec<T>, layout: MemoryLayout<N>, dim: [usize; N]) -> Self {
         // compute stride if necessary
         let stride = compute_stride(&dim, &layout);
 

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -285,6 +285,25 @@ where
     }
 }
 
+/// The policy used to implement the [PartialEq] trait is based on Kokkos'
+/// [`equal` algorithm](https://kokkos.github.io/kokkos-core-wiki/API/algorithms/std-algorithms/all/StdEqual.html).
+/// Essentially, it corresponds to equality by reference instead of equality by value.
+impl<const N: usize, T> PartialEq for View<N, T>
+where
+    T: DataTraits,
+{
+    fn eq(&self, other: &Self) -> bool {
+        // kokkos implements equality by reference
+        // i.e. two views are equal if they reference
+        // the same memory space.
+        self.data.as_ptr() == other.data.as_ptr()
+        // meta data just needs strict equality
+            && self.layout == other.layout
+            && self.dim == other.dim
+            && self.stride == other.stride
+    }
+}
+
 /// **Read-only access is always implemented.**
 impl<const N: usize, T> Index<[usize; N]> for View<N, T>
 where

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -39,9 +39,6 @@
 
 pub mod parameters;
 
-#[cfg(any(feature = "rayon", feature = "threads", feature = "gpu"))]
-use atomic::{Atomic, Ordering};
-
 use self::parameters::{compute_stride, DataTraits, MemoryLayout, MemorySpace, ViewData};
 use std::fmt::Debug;
 

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -65,7 +65,7 @@ pub enum ViewError<'a> {
 #[derive(Debug, PartialEq)]
 /// Common structure used as the backend of all `View` types. The main differences between
 /// usable types is the type of the `data` field.
-pub struct ViewBase<'a, const N: usize, T>
+pub struct View<'a, const N: usize, T>
 where
     T: DataTraits,
 {
@@ -87,7 +87,7 @@ where
 
 #[cfg(not(any(feature = "rayon", feature = "threads", feature = "gpu")))]
 // ~~~~~~~~ Constructors
-impl<'a, const N: usize, T> ViewBase<'a, N, T>
+impl<'a, const N: usize, T> View<'a, N, T>
 where
     T: DataTraits, // fair assumption imo
 {
@@ -127,7 +127,7 @@ where
 
 #[cfg(any(feature = "rayon", feature = "threads", feature = "gpu"))]
 // ~~~~~~~~ Constructors
-impl<'a, const N: usize, T> ViewBase<'a, N, T>
+impl<'a, const N: usize, T> View<'a, N, T>
 where
     T: DataTraits, // fair assumption imo
 {
@@ -166,7 +166,7 @@ where
 }
 
 // ~~~~~~~~ Uniform writing interface across all features
-impl<'a, const N: usize, T> ViewBase<'a, N, T>
+impl<'a, const N: usize, T> View<'a, N, T>
 where
     T: DataTraits,
 {
@@ -356,7 +356,7 @@ where
 }
 
 /// **Read-only access is always implemented.**
-impl<'a, const N: usize, T> Index<[usize; N]> for ViewBase<'a, N, T>
+impl<'a, const N: usize, T> Index<[usize; N]> for View<'a, N, T>
 where
     T: DataTraits,
 {
@@ -383,7 +383,7 @@ where
 
 #[cfg(not(any(feature = "rayon", feature = "threads", feature = "gpu")))]
 /// **Read-write access is only implemented when no parallel features are enabled.**
-impl<'a, const N: usize, T> IndexMut<[usize; N]> for ViewBase<'a, N, T>
+impl<'a, const N: usize, T> IndexMut<[usize; N]> for View<'a, N, T>
 where
     T: DataTraits,
 {
@@ -404,12 +404,12 @@ where
 }
 
 /// View type owning the data it yields access to, i.e. "original" view.
-pub type ViewOwned<'a, const N: usize, T> = ViewBase<'a, N, T>;
+pub type ViewOwned<'a, const N: usize, T> = View<'a, N, T>;
 
 /// View type owning a read-only borrow to the data it yields access to, i.e. a
 /// read-only mirror.
-pub type ViewRO<'a, const N: usize, T> = ViewBase<'a, N, T>;
+pub type ViewRO<'a, const N: usize, T> = View<'a, N, T>;
 
 /// View type owning a mutable borrow to the data it yields access to, i.e. a
 /// read-write mirror.
-pub type ViewRW<'a, const N: usize, T> = ViewBase<'a, N, T>;
+pub type ViewRW<'a, const N: usize, T> = View<'a, N, T>;

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -265,7 +265,7 @@ where
     pub fn raw_val(self) -> Vec<T> {
         (0..self.data.size)
             // the Deref should result in copied values, hence not pose any problem with the deallocation.
-            .map(|idx| unsafe { *self.data.ptr.add(idx) })
+            .map(|idx| self.data.get(idx))
             .collect()
     }
 
@@ -276,7 +276,7 @@ where
     pub fn raw_val(self) -> Vec<T> {
         (0..self.data.size)
             // the Deref should result in copied values, hence not pose any problem with the deallocation.
-            .map(|idx| unsafe { (*self.data.ptr.add(idx)).load(atomic::Ordering::Relaxed) })
+            .map(|idx| self.data.get(idx))
             .collect()
     }
 
@@ -302,7 +302,7 @@ where
         // kokkos implements equality by reference
         // i.e. two views are equal if they reference
         // the same memory space.
-        self.data.ptr == other.data.ptr
+        self.data.ptr_is_eq(&other.data)
         // meta data just needs strict equality
             && self.layout == other.layout
             && self.dim == other.dim

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -22,10 +22,10 @@
 //! ```rust
 //! use poc_kokkos_rs::view::{
 //!     parameters::Layout,
-//!     ViewOwned,
+//!     View,
 //! };
 //!
-//! let mut viewA: ViewOwned<'_, 2, f64> = ViewOwned::new(
+//! let mut viewA: View<'_, 2, f64> = View::new(
 //!         Layout::Right, // see parameters & Kokkos doc
 //!         [3, 5],        // 3 rows, 5 columns
 //!     );
@@ -345,6 +345,3 @@ where
         }
     }
 }
-
-/// View type owning the data it yields access to, i.e. "original" view.
-pub type ViewOwned<'a, const N: usize, T> = View<'a, N, T>;

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -1,12 +1,7 @@
 //! data structure related code
 //!
-//! This module contains code used for the implementations of `Views`, a data structure
-//! defined and used by the Kokkos library. There are different types of views, all
-//! implemented using the same backend, [ViewBase].
-//!
-//! Eventually, the different types of Views should be removed and replaced by a single
-//! type. The distinction between original and mirrors doesn't seem necessary in a Rust
-//! implementation where the ownership system handles all memory transaction.
+//! This module contains code used for the implementations of *Views*, a data structure
+//! defined and used by the Kokkos library.
 //!
 //! In order to have thread-safe structures to use in parallel statement, the inner data
 //! type of views is adjusted implicitly when compiling using parallelization features.
@@ -63,8 +58,10 @@ pub enum ViewError<'a> {
 }
 
 #[derive(Debug, PartialEq)]
-/// Common structure used as the backend of all `View` types. The main differences between
-/// usable types is the type of the `data` field.
+/// Main View structure.
+///
+/// A `View` represent an N-dimensionnal array of type T. The implementation uses a
+/// const generic to handle dimension-specific operations.
 pub struct View<'a, const N: usize, T>
 where
     T: DataTraits,
@@ -78,7 +75,7 @@ where
     /// - be a vector (1 dimension)
     /// - be a multi-dimensionnal array (up to 8 dimensions)
     /// The number of dimensions is referred to as the _depth_. Dimension 0, i.e. scalar,
-    /// is not directly supported.
+    /// is not directly supported at the moment.
     pub dim: [usize; N],
     /// Stride between each element of a given dimension. Computed automatically for
     /// [Layout::Left] and [Layout::Right].

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -79,7 +79,6 @@ where
     pub stride: [usize; N],
 }
 
-#[cfg(not(any(feature = "rayon", feature = "threads", feature = "gpu")))]
 // ~~~~~~~~ Constructors
 impl<const N: usize, T> View<N, T>
 where
@@ -104,48 +103,6 @@ where
     }
 
     /// Constructor.
-    pub fn new_from_data(data: Vec<T>, layout: MemoryLayout<N>, dim: [usize; N]) -> Self {
-        // compute stride if necessary
-        let stride = compute_stride(&dim, &layout);
-        let capacity: usize = dim.iter().product();
-
-        let mut viewdata: ViewData<T> = ViewData::new(capacity, MemorySpace::CPU);
-        viewdata.take_vals(&data);
-
-        // build & return
-        Self {
-            data: viewdata,
-            layout,
-            dim,
-            stride,
-        }
-    }
-}
-
-#[cfg(any(feature = "rayon", feature = "threads", feature = "gpu"))]
-// ~~~~~~~~ Constructors
-impl<const N: usize, T> View<N, T>
-where
-    T: DataTraits, // fair assumption imo
-{
-    /// Constructor used to create owned views.
-    pub fn new(layout: MemoryLayout<N>, dim: [usize; N]) -> Self {
-        // compute stride & capacity
-        let stride = compute_stride(&dim, &layout);
-        let capacity: usize = dim.iter().product();
-
-        let data: ViewData<T> = ViewData::new(capacity, MemorySpace::CPU);
-
-        // build & return
-        Self {
-            data,
-            layout,
-            dim,
-            stride,
-        }
-    }
-
-    /// Constructor used to create owned views. See dedicated methods for others.
     pub fn new_from_data(data: Vec<T>, layout: MemoryLayout<N>, dim: [usize; N]) -> Self {
         // compute stride if necessary
         let stride = compute_stride(&dim, &layout);

--- a/src/view/parameters.rs
+++ b/src/view/parameters.rs
@@ -139,7 +139,7 @@ impl<T: DataTraits> ViewData<T> {
     /// **Current version**: no-feature
     pub fn get(&self, idx: usize) -> T {
         assert!(idx < self.size);
-        unsafe { *self.ptr.add(idx).as_ref().unwrap() }
+        unsafe { *self.ptr.add(idx) }
     }
 
     #[cfg(any(feature = "rayon", feature = "threads", feature = "gpu"))]
@@ -158,13 +158,7 @@ impl<T: DataTraits> ViewData<T> {
     /// **Current version**: thread-safe
     pub fn get(&self, idx: usize) -> T {
         assert!(idx < self.size);
-        unsafe {
-            self.ptr
-                .add(idx)
-                .as_ref()
-                .unwrap()
-                .load(atomic::Ordering::Relaxed)
-        }
+        unsafe { (*self.ptr.add(idx)).load(atomic::Ordering::Relaxed) }
     }
 
     #[cfg(not(any(feature = "rayon", feature = "threads", feature = "gpu")))]

--- a/src/view/parameters.rs
+++ b/src/view/parameters.rs
@@ -52,6 +52,8 @@ pub type InnerDataType<T> = T;
 /// **Current version**: thread-safe
 pub type InnerDataType<T> = Atomic<T>;
 
+// ~~~~~~~~~ Layouts ~~~~~~~~~
+
 /// Enum used to represent data layout. Struct enums is used in order to increase
 /// readability.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
@@ -97,6 +99,15 @@ pub fn compute_stride<const N: usize>(dim: &[usize; N], layout: &Layout<N>) -> [
         Layout::Stride { s } => *s,
     }
 }
+
+// ~~~~~~~~~ Memory space ~~~~~~~~~
+
+pub enum MemorySpace {
+    Host,
+    Device,
+}
+
+// ~~~~~~~~~ Tests ~~~~~~~~~
 
 #[cfg(test)]
 mod tests {

--- a/src/view/parameters.rs
+++ b/src/view/parameters.rs
@@ -75,17 +75,17 @@ impl<T: DataTraits> ViewData<T> {
     }
 
     #[cfg(not(any(feature = "rayon", feature = "threads", feature = "gpu")))]
-    pub fn get(&self, idx: isize) -> &T {
-        assert!((idx as usize) < self.size);
-        unsafe { self.ptr.offset(idx).as_ref().unwrap() }
+    pub fn get(&self, idx: usize) -> &T {
+        assert!(idx < self.size);
+        unsafe { self.ptr.add(idx).as_ref().unwrap() }
     }
 
     #[cfg(any(feature = "rayon", feature = "threads", feature = "gpu"))]
-    pub fn get(&self, idx: isize) -> T {
-        assert!((idx as usize) < self.size);
+    pub fn get(&self, idx: usize) -> T {
+        assert!(idx < self.size);
         unsafe {
             self.ptr
-                .offset(idx)
+                .add(idx)
                 .as_ref()
                 .unwrap()
                 .load(atomic::Ordering::Relaxed)
@@ -93,21 +93,21 @@ impl<T: DataTraits> ViewData<T> {
     }
 
     #[cfg(not(any(feature = "rayon", feature = "threads", feature = "gpu")))]
-    pub fn set(&self, idx: isize, val: T) {
-        assert!((idx as usize) < self.size);
-        let targ = unsafe { self.ptr.offset(idx) };
+    pub fn set(&self, idx: usize, val: T) {
+        assert!(idx < self.size);
+        let targ = unsafe { self.ptr.add(idx) };
         unsafe { *targ = val };
     }
 
     #[cfg(any(feature = "rayon", feature = "threads", feature = "gpu"))]
-    pub fn set(&self, idx: isize, val: T) {
-        assert!((idx as usize) < self.size);
-        let targ = unsafe { self.ptr.offset(idx) };
+    pub fn set(&self, idx: usize, val: T) {
+        assert!(idx < self.size);
+        let targ = unsafe { self.ptr.add(idx) };
         unsafe { (*targ).store(val, atomic::Ordering::Relaxed) };
     }
 
     pub fn fill(&mut self, val: T) {
-        for idx in 0..self.size as isize {
+        for idx in 0..self.size {
             self.set(idx, val);
         }
     }

--- a/src/view/parameters.rs
+++ b/src/view/parameters.rs
@@ -65,11 +65,11 @@ where
     T: DataTraits,
 {
     #[cfg(not(any(feature = "rayon", feature = "threads", feature = "gpu")))]
-    pub ptr: *mut InnerDataType<T>,
+    ptr: *mut InnerDataType<T>,
     #[cfg(any(feature = "rayon", feature = "threads", feature = "gpu"))]
-    pub ptr: *const InnerDataType<T>,
+    ptr: *const InnerDataType<T>,
+    lyt: Layout,
     pub size: usize,
-    pub lyt: Layout,
     pub mirror: bool,
 }
 
@@ -127,6 +127,10 @@ impl<T: DataTraits> ViewData<T> {
         vals.iter()
             .enumerate()
             .for_each(|(idx, val)| self.set(idx, *val))
+    }
+
+    pub fn ptr_is_eq(&self, other: &Self) -> bool {
+        self.ptr == other.ptr
     }
 }
 

--- a/src/view/parameters.rs
+++ b/src/view/parameters.rs
@@ -64,7 +64,10 @@ pub struct ViewData<T>
 where
     T: DataTraits,
 {
+    #[cfg(not(any(feature = "rayon", feature = "threads", feature = "gpu")))]
     pub ptr: *mut InnerDataType<T>,
+    #[cfg(any(feature = "rayon", feature = "threads", feature = "gpu"))]
+    pub ptr: *const InnerDataType<T>,
     pub size: usize,
     pub lyt: Layout,
     pub mirror: bool,
@@ -135,6 +138,10 @@ impl<T: DataTraits> Drop for ViewData<T> {
         }
     }
 }
+
+unsafe impl<T: DataTraits> Sync for ViewData<T> {}
+
+unsafe impl<T: DataTraits> Send for ViewData<T> {}
 
 // ~~~~~~~~~ Memory layout ~~~~~~~~~
 

--- a/src/view/parameters.rs
+++ b/src/view/parameters.rs
@@ -82,9 +82,9 @@ impl<T: DataTraits> ViewData<T> {
     }
 
     #[cfg(not(any(feature = "rayon", feature = "threads", feature = "gpu")))]
-    pub fn get(&self, idx: usize) -> &T {
+    pub fn get(&self, idx: usize) -> T {
         assert!(idx < self.size);
-        unsafe { self.ptr.add(idx).as_ref().unwrap() }
+        unsafe { *self.ptr.add(idx).as_ref().unwrap() }
     }
 
     #[cfg(any(feature = "rayon", feature = "threads", feature = "gpu"))]

--- a/src/view/parameters.rs
+++ b/src/view/parameters.rs
@@ -52,51 +52,6 @@ pub type InnerDataType<T> = T;
 /// **Current version**: thread-safe
 pub type InnerDataType<T> = Atomic<T>;
 
-#[derive(Debug)]
-/// Enum used to identify the type of data the view is holding.
-///
-/// This should eventually be removed. See the [view][crate::view] module documentation
-/// for more information.
-///
-/// The policy used to implement the [PartialEq] trait is based on Kokkos'
-/// [`equal` algorithm](https://kokkos.github.io/kokkos-core-wiki/API/algorithms/std-algorithms/all/StdEqual.html).
-/// Essentially, it corresponds to equality by reference instead of equality by value.
-pub enum DataType<'a, T>
-where
-    T: DataTraits,
-{
-    /// The view owns the data.
-    Owned(Vec<InnerDataType<T>>),
-    /// The view borrows the data and can only read it.
-    Borrowed(&'a [InnerDataType<T>]),
-    /// The view borrows the data and can both read and modify it.
-    MutBorrowed(&'a mut [InnerDataType<T>]),
-}
-
-impl<'a, T> PartialEq for DataType<'a, T>
-where
-    T: DataTraits,
-{
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            // are the deref operations necessary?
-            // this one is technically necessary because self==self should return true
-            (Self::Owned(l0), Self::Owned(r0)) => (*l0).as_ptr() == (*r0).as_ptr(),
-            // compare pointers
-            // deref Owned only once, twice the others
-            (Self::Owned(l0), Self::Borrowed(r0)) => (*l0).as_ptr() == (**r0).as_ptr(),
-            (Self::Owned(l0), Self::MutBorrowed(r0)) => (*l0).as_ptr() == (**r0).as_ptr(),
-            (Self::Borrowed(l0), Self::Owned(r0)) => (**l0).as_ptr() == (*r0).as_ptr(),
-            (Self::MutBorrowed(l0), Self::Owned(r0)) => (**l0).as_ptr() == (*r0).as_ptr(),
-
-            (Self::Borrowed(l0), Self::Borrowed(r0)) => (**l0).as_ptr() == (**r0).as_ptr(),
-            (Self::Borrowed(l0), Self::MutBorrowed(r0)) => (**l0).as_ptr() == (**r0).as_ptr(),
-            (Self::MutBorrowed(l0), Self::MutBorrowed(r0)) => (**l0).as_ptr() == (**r0).as_ptr(),
-            (Self::MutBorrowed(l0), Self::Borrowed(r0)) => (**l0).as_ptr() == (**r0).as_ptr(),
-        }
-    }
-}
-
 /// Enum used to represent data layout. Struct enums is used in order to increase
 /// readability.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]

--- a/src/view/parameters.rs
+++ b/src/view/parameters.rs
@@ -422,14 +422,14 @@ mod viewdata {
 
     #[test]
     fn default_value() {
-        let dat: ViewData<f64> = ViewData::new(SIZE, MemorySpace::CPU);
+        let mut dat: ViewData<f64> = ViewData::new(SIZE, MemorySpace::CPU);
+        dat.fill(f64::default());
         (0..SIZE).for_each(|idx| assert_eq!(f64::default(), dat.get(idx)))
     }
 
     #[test]
     fn fill() {
         let mut dat: ViewData<f64> = ViewData::new(SIZE, MemorySpace::CPU);
-        (0..SIZE).for_each(|idx| assert_eq!(f64::default(), dat.get(idx)));
         dat.fill(9534.284);
         (0..SIZE).for_each(|idx| assert_eq!(9534.284, dat.get(idx)));
     }

--- a/src/view/parameters.rs
+++ b/src/view/parameters.rs
@@ -73,14 +73,12 @@ where
 impl<T: DataTraits> ViewData<T> {
     pub fn new(size: usize, memspace: MemorySpace) -> Self {
         let (ptr, lyt) = allocate_block::<InnerDataType<T>>(size, memspace).unwrap();
-        let mut tmp = Self {
+        Self {
             ptr,
             size,
             lyt,
             mirror: false,
-        };
-        tmp.fill(T::default()); // ensure initialization
-        tmp
+        }
     }
 
     #[cfg(not(any(feature = "rayon", feature = "threads", feature = "gpu")))]

--- a/src/view/parameters.rs
+++ b/src/view/parameters.rs
@@ -57,7 +57,7 @@ pub type InnerDataType<T> = Atomic<T>;
 /// Enum used to represent data layout. Struct enums is used in order to increase
 /// readability.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
-pub enum Layout<const N: usize> {
+pub enum MemoryLayout<const N: usize> {
     /// Highest stride for the first index, decreasing stride as index increases.
     /// Exact stride for each index can be computed from dimensions at view initialization.
     #[default]
@@ -70,10 +70,10 @@ pub enum Layout<const N: usize> {
 }
 
 /// Compute correct strides of each index using dimensions and specified layout.
-pub fn compute_stride<const N: usize>(dim: &[usize; N], layout: &Layout<N>) -> [usize; N] {
+pub fn compute_stride<const N: usize>(dim: &[usize; N], layout: &MemoryLayout<N>) -> [usize; N] {
     assert_eq!(N.clamp(1, MAX_VIEW_DEPTH), N); // 1 <= N <= MAX_N
     match layout {
-        Layout::Right => {
+        MemoryLayout::Right => {
             let mut stride = [1; N];
 
             let mut tmp: usize = 1;
@@ -85,7 +85,7 @@ pub fn compute_stride<const N: usize>(dim: &[usize; N], layout: &Layout<N>) -> [
             stride.reverse();
             stride
         }
-        Layout::Left => {
+        MemoryLayout::Left => {
             let mut stride = [1; N];
 
             let mut tmp: usize = 1;
@@ -96,7 +96,7 @@ pub fn compute_stride<const N: usize>(dim: &[usize; N], layout: &Layout<N>) -> [
 
             stride
         }
-        Layout::Stride { s } => *s,
+        MemoryLayout::Stride { s } => *s,
     }
 }
 
@@ -118,7 +118,7 @@ mod tests {
         // dim = [n0, n1, n2, n3]
         let dim = [3, 4, 5, 6];
 
-        let cmp_stride = compute_stride(&dim, &Layout::Right);
+        let cmp_stride = compute_stride(&dim, &MemoryLayout::Right);
         // n3 * n2 * n1, n3 * n2, n3, 1
         let ref_stride: [usize; 4] = [6 * 5 * 4, 6 * 5, 6, 1];
 
@@ -130,7 +130,7 @@ mod tests {
         // dim = [n0, n1, n2, n3]
         let dim = [3, 4, 5, 6];
 
-        let cmp_stride = compute_stride(&dim, &Layout::Left);
+        let cmp_stride = compute_stride(&dim, &MemoryLayout::Left);
         // 1, n0, n0 * n1, n0 * n1 * n2
         let ref_stride: [usize; 4] = [1, 3, 3 * 4, 3 * 4 * 5];
 
@@ -142,9 +142,9 @@ mod tests {
         // 1d view (vector) of length 1
         let dim: [usize; 1] = [8];
         let ref_stride: [usize; 1] = [1];
-        let mut cmp_stride = compute_stride(&dim, &Layout::Right);
+        let mut cmp_stride = compute_stride(&dim, &MemoryLayout::Right);
         assert_eq!(ref_stride, cmp_stride);
-        cmp_stride = compute_stride(&dim, &Layout::Left);
+        cmp_stride = compute_stride(&dim, &MemoryLayout::Left);
         assert_eq!(ref_stride, cmp_stride);
     }
 }


### PR DESCRIPTION
- Replaced internal Vec of views by a custome structure, `ViewData`
- updated all interfaces accordingly
- Removed DataType enum; the Rust ownership system coupled with explicit mirroring will be enough
- doc update